### PR TITLE
Fix : loupe image fiche paleo

### DIFF
--- a/plugins/ArchivesPlugin/types/Paleography/doPaleographyFullDisplay.jsp
+++ b/plugins/ArchivesPlugin/types/Paleography/doPaleographyFullDisplay.jsp
@@ -23,7 +23,9 @@
          <div class="ds44-inner-container">
             <div class="ds44-grid12-offset-1">
                <jalios:if predicate="<%= Util.notEmpty(obj.getTextRecall()) %>">
-                   <ds:figurePicture imgCss="ds44-w100" figureCss="ds44-legendeContainer ds44-imgLoupe" format="unchanged" image="<%= obj.getTextRecall() %>" imageMobile="<%= obj.getTextRecall() %>"/>
+                   <figure class="ds44-legendeContainer ds44-imgLoupe" role="figure">
+                       <img class="ds44-w100" src="<%= obj.getTextRecall() %>">
+                   </figure>
                </jalios:if>
                <div class="ds44-theme ds44-flex-valign-center ds44-flex-container ds44-fse ds44--l-padding ">
                   <span class="ds44-docListElem"><i class="icon icon-tag ds44-docListIco" aria-hidden="true"></i><%= SocleUtils.formatCategories(obj.getLevels(loggedMember)) %></span>


### PR DESCRIPTION
Je n'utiliserai pas le tag, car j'ai eu des soucis de loupe qui n'était pas générée correctement via JS. J'ai préféré repartir sur des balises HTML classique directement dans le gabarit, d'autant plus que c'est un cas spécifique.