### PR TITLE
Evol form archives demande renseignement

### DIFF
--- a/WEB-INF/classes/fr/cg44/plugin/archives/ArchivesMailUtils.java
+++ b/WEB-INF/classes/fr/cg44/plugin/archives/ArchivesMailUtils.java
@@ -1,5 +1,6 @@
 package fr.cg44.plugin.archives;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -15,6 +16,8 @@ import fr.cg44.plugin.socle.SocleUtils;
 import generated.AutreRechercheForm;
 import generated.CommunicationForm;
 import generated.RechercheJugementForm;
+
+import fr.cg44.plugin.socle.MailUtils;
 
 public final class ArchivesMailUtils {
   private static Channel channel = Channel.getChannel();
@@ -148,7 +151,7 @@ public final class ArchivesMailUtils {
   /**
    * Envoi de l'email du formulaire autre recherche (site Archives)
    */
-  public static boolean envoiMailAutreRechercheArchives(AutreRechercheForm form) {
+  public static boolean envoiMailAutreRechercheArchives(AutreRechercheForm form, ArrayList<File> fichiers) {
     
     boolean result = false;
     String jsp = "/plugins/SoclePlugin/jsp/mail/formulaireArchivesAutreRechercheTemplate.jsp";
@@ -182,11 +185,18 @@ public final class ArchivesMailUtils {
 
     if (Util.notEmpty(emailFrom) && Util.notEmpty(emailTo)) {
       try {
-        MailUtils.sendMail(objet, null, emailFrom, emailTo, listeEmailCC, null, jsp, parametersMap);
+        MailUtils.sendMail(objet, null, emailFrom, emailTo, listeEmailCC, fichiers, jsp, parametersMap);
         result = true;
       } catch (Exception e) {
         result = false;
         LOGGER.error("AutreRechercheForm - Erreur lors de l'envoi du mail : " + e.getMessage());
+      }
+      finally {
+        if(result) {
+          MailUtils.msgEnvoiMailContact();          
+        }else {
+          MailUtils.msgEchecEnvoiMailContact();
+        }
       }
 
     } else {

--- a/WEB-INF/data/types/AutreRechercheForm/AutreRechercheForm.xml
+++ b/WEB-INF/data/types/AutreRechercheForm/AutreRechercheForm.xml
@@ -36,7 +36,10 @@
     </field>
     <field name="demande" editor="textarea" required="false" compactDisplay="false" type="String" searchable="false" rows="5" cols="80" ml="false" wiki="false" wikiwyg="false" html="false" checkHtml="false">
       <label xml:lang="fr">Demande</label>
-    </field> 
+    </field>
+    <field name="justificatif" editor="textfield" required="false" compactDisplay="false" type="String" searchable="false" size="80" ml="false" html="false" checkHtml="false">
+      <label xml:lang="fr">Justificatif</label>
+    </field>    
  </fields>
 </type>
 

--- a/WEB-INF/plugins/ArchivesPlugin/plugin.xml
+++ b/WEB-INF/plugins/ArchivesPlugin/plugin.xml
@@ -50,6 +50,10 @@
   <java-classes>
     <java package="fr.cg44.plugin.archives"/>   
   </java-classes>
+  
+  <plugincomponents>
+    <datacontroller  class="fr.cg44.plugin.archives.datacontroller.AutreRechercheFormDataController" types="AutreRechercheForm" />
+  </plugincomponents>  
     
   <private-files>
     <file path="properties/plugin.prop" />

--- a/WEB-INF/plugins/ArchivesPlugin/properties/languages/fr.prop
+++ b/WEB-INF/plugins/ArchivesPlugin/properties/languages/fr.prop
@@ -41,6 +41,7 @@ jcmsplugin.archives.form.motivations: Mention texte libre
 jcmsplugin.archives.form.motifDivorce: Divorce
 jcmsplugin.archives.form.motifAdoption: Adoption
 jcmsplugin.archives.form.motifAutre: Autre
+jcmsplugin.archives.form.piece-jointe: Pièce jointe 
 
 jcmsplugin.archives.form.votre-demande : Votre demande
 
@@ -49,6 +50,7 @@ jcmsplugin.archives.form.ctrl.datesJugement: Merci de renseigner une date (anné
 
 jcmsplugin.archives.form.exemple.anneeJugement: Exemple : 1939
 jcmsplugin.archives.form.exemple.dateJugement: Exemple : 25/03/1939
+jcmsplugin.archives.form.autreRecherche.exemple.formats: Formats : PDF ou image, taille max. : 6Mo
 
 # ------------------------------------------------------------
 #  Email

--- a/WEB-INF/plugins/ArchivesPlugin/properties/plugin.prop
+++ b/WEB-INF/plugins/ArchivesPlugin/properties/plugin.prop
@@ -36,6 +36,7 @@ jcmsplugin.archives.form.mailTo: archives@loire-atlantique.fr
 jcmsplugin.archives.form.from: archives@loire-atlantique.fr
 jcmsplugin.socle.form.contact.mailTo: archives@loire-atlantique.fr
 $jcmsplugin.socle.form.contactform.sujet.root: c_25802
+jcmsplugin.socle.form.autreRecherche.file.size.max: 6291456
 
 # Périodique
 

--- a/plugins/ArchivesPlugin/types/AutreRechercheForm/doEditAutreRechercheForm.jsp
+++ b/plugins/ArchivesPlugin/types/AutreRechercheForm/doEditAutreRechercheForm.jsp
@@ -1,23 +1,13 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ include file='/jcore/doInitPage.jspf' %>
-
-<%
-String formAction = "plugins/SoclePlugin/jsp/forms/checkArchivesAutreRecherche.jsp";
+<% 
+  EditAutreRechercheFormHandler formHandler = (EditAutreRechercheFormHandler)request.getAttribute("formHandler");
+  ServletUtil.backupAttribute(pageContext, "classBeingProcessed");
+  request.setAttribute("classBeingProcessed", generated.AutreRechercheForm.class);
 %>
 
-<div class="ds44-loader-text visually-hidden" tabindex="-1" aria-live="polite"></div>
-<div class="ds44-loader hidden">
-    <div class="ds44-loader-body">
-        <svg class="ds44-loader-circular" focusable="false" aria-hidden="true">
-            <circle class="ds44-loader-path" cx="30" cy="30" r="20" fill="none" stroke-width="5" stroke-miterlimit="10"></circle>
-        </svg>
-    </div>
-</div>
 
-<article class="ds44-container-large ds44-mtb5">
-    <div class="ds44-inner-container ds44-grid12-offset-1">
-        <p class="ds44-textLegend ds44-textLegend--mentions"><%= glp("jcmsplugin.socle.facette.champs-obligatoires") %></p>
-        <form data-is-ajax='true' data-is-inline="true" data-empty-after-submit="true" action='<%= formAction %>' method="post">
+        
             <div class="ds44-mb3">
                 <h2 class="h3-like"><%= glp("jcmsplugin.archives.form.vous-etes") %></h2>
                 <ul class="ds44-list grid-12">
@@ -143,6 +133,39 @@ String formAction = "plugins/SoclePlugin/jsp/forms/checkArchivesAutreRecherche.j
                                 </div>
                             </div>
                         </li>
+                        
+                        <%-- Justificatif ------------------------------------------------------------ --%>
+						<% String justificatifLabel = glp("jcmsplugin.archives.form.piece-jointe");%>
+						<li class="col-12">
+							<div class="ds44-mb3">
+							    <div class="ds44-form__container">
+							        <div class="ds44-posRel">
+							            <label id="label-form-element-justificatif" for="form-element-justificatif" class="ds44-formLabel">
+							                <span class="ds44-labelTypePlaceholder"><span><%= justificatifLabel %></span></span>
+							            </label>
+							            
+							            <div class="ds44-file__shape ds44-inpStd">
+							                <input type="file" id="form-element-justificatif" name="justificatif" title="<%= glp("jcmsplugin.socle.facette.champ-obligatoire.title", justificatifLabel) %>" data-file-extensions="doc,docx,png,gif,jpg,jpeg,pdf" aria-describedby="explanation-form-element-justificatif"  />
+							                <div id="file-display-form-element-justificatif" class="ds44-fileDisplay"></div>
+							            </div>
+							            <button class="ds44-reset" type="button" aria-describedby="label-form-element-justificatif">
+							              <i class="icon icon-cross icon--sizeL" aria-hidden="true"></i><span class="visually-hidden"><%= glp("jcmsplugin.socle.facette.effacer-contenu-champ", justificatifLabel) %></span>
+							            </button>
+							        
+							            <span class="ds44-file" aria-hidden="true"><i class="icon icon-directory icon--medium" aria-hidden="true"></i></span>
+							        
+							        </div>
+							    
+							        <div class="ds44-field-information" aria-live="polite">
+							            <ul class="ds44-field-information-list ds44-list">
+							                <li id="explanation-form-element-justificatif" class="ds44-field-information-explanation"><%= glp("jcmsplugin.archives.form.autreRecherche.exemple.formats") %></li>
+							            </ul>
+							        </div>
+							    
+							    </div>
+							</div>
+                        </li>
+                        
                     </ul>
             </div>            
 
@@ -152,10 +175,9 @@ String formAction = "plugins/SoclePlugin/jsp/forms/checkArchivesAutreRecherche.j
                     <i class="icon icon-long-arrow-right" aria-hidden="true"></i>
                 </button>
             </div>
-        </form>
 
-    </div>
-</article>
+
+
 
  
 

--- a/plugins/ArchivesPlugin/types/AutreRechercheForm/editFormAutreRechercheForm.jsp
+++ b/plugins/ArchivesPlugin/types/AutreRechercheForm/editFormAutreRechercheForm.jsp
@@ -1,6 +1,73 @@
-<%@ page contentType="text/html; charset=UTF-8" %>
-<%@ include file='/jcore/doInitPage.jspf' %>
+<%@ page contentType="text/html; charset=UTF-8" %><%
+%><%@ taglib prefix="ds" tagdir="/WEB-INF/tags"%><%
+%><%@ include file='/jcore/doInitPage.jspf' %>
+<% String[] formTitles = JcmsUtil.getLanguageArray(channel.getTypeEntry(AutreRechercheForm.class).getLabelMap()); %>
+<jsp:useBean id='formHandler' scope='page' class='generated.EditAutreRechercheFormHandler'>
+  <jsp:setProperty name='formHandler' property='request' value='<%= request %>'/>
+  <jsp:setProperty name='formHandler' property='response' value='<%= response %>'/>
+  <jsp:setProperty name='formHandler' property='*' />
+  <jsp:setProperty name='formHandler' property='author' value='j_2'/>
+  <jsp:setProperty name='formHandler' property='title' value='<%= formTitles %>'/>
+</jsp:useBean>
+<%
+  if (formHandler.validate()) {
+    return;
+  }
+%>   
+
+<jalios:if predicate='<%= formHandler.isOneSubmit() && formHandler.isSubmitted() %>'>
+  <% setWarningMsg(glp("msg.edit.already-one-submit"), request); %>
+</jalios:if>
 
 <jalios:if predicate='<%= channel.isDataWriteEnabled() %>'>
-    <jsp:include page="doEditAutreRechercheForm.jsp" />
+
+<%-- -- FORM -------------------------------------------- --%>
+<jalios:query name='__memberSet' dataset='<%= channel.getDataSet(Member.class) %>' comparator='<%= Member.getNameComparator() %>'/>
+<% request.setAttribute("formMemberSet", __memberSet); %>
+<jalios:query name='__groupSet' dataset='<%= channel.getDataSet(Group.class) %>' comparator='<%= Group.getNameComparator() %>'/>
+<% request.setAttribute("formGroupSet", __groupSet); %>
+
+
+<div class="ds44-loader-text visually-hidden" tabindex="-1" aria-live="polite"></div>
+<div class="ds44-loader hidden">
+    <div class="ds44-loader-body">
+        <svg class="ds44-loader-circular" focusable="false" aria-hidden="true">
+            <circle class="ds44-loader-path" cx="30" cy="30" r="20" fill="none" stroke-width="5" stroke-miterlimit="10"></circle>
+        </svg>
+    </div>
+</div>
+
+<article class="ds44-container-large ds44-mtb5">
+    <div class="ds44-inner-container ds44-grid12-offset-1">
+    
+        <%@ include file='/plugins/SoclePlugin/jsp/doMessageBoxCustom.jspf' %>
+        
+        <p class="ds44-textLegend ds44-textLegend--mentions"><%= glp("jcmsplugin.socle.facette.champs-obligatoires") %></p>
+
+		<%
+		Publication currentPub = (Publication) request.getAttribute(PortalManager.PORTAL_PUBLICATION);
+		String formAction = "plugins/SoclePlugin/jsp/forms/doFormDecodeParams.jsp";
+		%>
+		<form action='<%= formAction %>' method='post' name='editForm' accept-charset="UTF-8" enctype="multipart/form-data">
+
+		    <%
+		    request.setAttribute("formHandler", formHandler);
+		    %>
+		
+		    <jsp:include page="doEditAutreRechercheForm.jsp" />
+		    
+		    <input type='hidden' name='redirect' value='<%= currentPub.getDisplayUrl(userLocale) %>' data-technical-field />
+		    <input type='hidden' name='ws' value='<%= formHandler.getWorkspace().getId() %>' data-technical-field />
+		    <input type='hidden' name='opCreate' value='<%= glp("ui.com.btn.submit") %>' data-technical-field />
+		    <input type="hidden" name="csrftoken" value="<%= HttpUtil.getCSRFToken(request) %>" data-technical-field>
+		    <input type="hidden" name="noSendRedirect" value='true' data-technical-field />
+		    <input type="hidden" name="id" value='<%= request.getParameter("id") %>' data-technical-field />
+		
+		</form>
+
+    </div>
+</article>
+
+<% request.setAttribute("idPortletBas", channel.getProperty("jcmsplugin.socle.form.candidature.portlet-rgpd.id")); %>
+
 </jalios:if>


### PR DESCRIPTION
Ajout d'un champ de type "file" pour uploader un justificatif. Le contrôle du formulaire ne se fait plus via JSP mais via DataController. Reprise de la mécanique de réponse aux offres d'emploi pour l'upload de fichiers.